### PR TITLE
Repair reinit! for scalar NoiseGrids

### DIFF
--- a/src/noise_interfaces/common.jl
+++ b/src/noise_interfaces/common.jl
@@ -49,9 +49,16 @@ function DiffEqBase.reinit!(W::AbstractNoiseProcess,dt;
   W.curt = t0
   W.dt = dt
   if typeof(W) <: NoiseGrid
-    W.curW .= W.W[1]
-    if W.Z != nothing
-      W.curZ .= W.Z[1]
+    if isinplace(W)
+      W.curW .= W.W[1]
+      if W.Z != nothing
+        W.curZ .= W.Z[1]
+      end
+    else
+      W.curW = W.W[1]
+      if W.Z != nothing
+        W.curZ = W.Z[1]
+      end
     end
     W.step_setup = true
   end


### PR DESCRIPTION
A missing `isinplace` check had `reinit!` broken for scalar NoiseGrids. Here's the fix.

Former behavior:
```julia
julia> using DifferentialEquations

julia> W = NoiseGrid([0.0, 1.0, 2.0], [0.0, 1.0, -0.5]);

julia> reinit!(W, 1.0)
ERROR: MethodError: no method matching broadcast!(::Base.#identity, ::Float64, ::Float64)
Closest candidates are:
  broadcast!(::Base.#identity, ::DiffEqJump.ExtendedJumpArray, ::Number) at /home/daniel/.julia/v0.6/DiffEqJump/src/extended_jump_array.jl:78
  broadcast!(::Base.#identity, ::AbstractArray, ::Number) at broadcast.jl:22
  broadcast!(::Any, ::DiffEqJump.ExtendedJumpArray, ::Union{DiffEqJump.ExtendedJumpArray, Number}...) at /home/daniel/.julia/v0.6/DiffEqJump/src/extended_jump_array.jl:42
  ...
Stacktrace:
 [1] #reinit!#52(::Float64, ::Bool, ::Bool, ::Function, ::DiffEqNoiseProcess.NoiseGrid{Float64,0,Float64,Float64,Void,Void,false}, ::Float64) at /home/daniel/.julia/v0.6/DiffEqNoiseProcess/src/noise_interfaces/common.jl:52
 [2] reinit!(::DiffEqNoiseProcess.NoiseGrid{Float64,0,Float64,Float64,Void,Void,false}, ::Float64) at /home/daniel/.julia/v0.6/DiffEqNoiseProcess/src/noise_interfaces/common.jl:49
```
New behavior:
```julia
julia> using DifferentialEquations

julia> W = NoiseGrid([0.0, 1.0, 2.0], [0.0, 1.0, -0.5]);

julia> reinit!(W, 1.0)
false 
```