### PR TITLE
WIP: v0.7 deprecations

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -33,7 +33,7 @@ mutable struct NoiseProcess{T,N,Tt,T2,T3,ZType,F,F2,inplace,S1,S2,RSWM,RNGType} 
                          rswm = RSWM(),save_everystep=true,timeseries_steps=1,
                          rng = Xorshifts.Xoroshiro128Plus(rand(UInt64)),
                          reset = true, reseed = true) where iip
-    S₁ = DataStructures.Stack(Tuple{typeof(t0),typeof(W0),typeof(Z0)})
+    S₁ = DataStructures.Stack{Tuple{typeof(t0),typeof(W0),typeof(Z0)}}()
     S₂ = ResettableStacks.ResettableStack(
                           Tuple{typeof(t0),typeof(W0),typeof(Z0)})
     if Z0==nothing

--- a/test/bridge_test.jl
+++ b/test/bridge_test.jl
@@ -3,7 +3,7 @@
 using DiffEqNoiseProcess, DiffEqBase, DiffEqMonteCarlo,
       Test, DataStructures, Random
 
-srand(100)
+Random.seed!(100)
 W = BrownianBridge(0.0,1.0,0.0,1.0,0.0,0.0)
 prob = NoiseProblem(W,(0.0,1.0))
 monte_prob = MonteCarloProblem(prob)

--- a/test/multi_dim.jl
+++ b/test/multi_dim.jl
@@ -4,7 +4,7 @@ using DiffEqNoiseProcess, Random, Statistics
 
 W = WienerProcess(0.0,rand(4,4),rswm=RSWM(adaptivealg=:RSwM3))
 
-srand(200)
+Random.seed!(200)
 dt = 0.2
 calculate_step!(W,dt)
 
@@ -22,7 +22,7 @@ end
 
 W = WienerProcess!(0.0,rand(4,4),rand(4,4),rswm=RSWM(adaptivealg=:RSwM3))
 
-srand(200)
+Random.seed!(200)
 dt = 0.2
 calculate_step!(W,dt)
 

--- a/test/sde_adaptivedistribution_tests.jl
+++ b/test/sde_adaptivedistribution_tests.jl
@@ -4,7 +4,7 @@ using StochasticDiffEq, StatsBase, Distributions, HypothesisTests
 using Random, DiffEqProblemLibrary
 
 prob = prob_sde_linear
-srand(200)
+Random.seed!(200)
 N = 100
 M= 5
 ps = Vector{Float64}(undef,M)


### PR DESCRIPTION
There are two instances of `srand` left in `solve.jl`, since the following error is generated when switching to `Random.seed!`:

```
  MethodError: no method matching seed!(::RandomNumbers.Xorshifts.Xoroshiro128Plus, ::UInt64)
  Closest candidates are:
    seed!(!Matched::MersenneTwister, ::Integer) at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v0.7/Random/src/RNGs.jl:289
    seed!(::AbstractRNG, !Matched::Nothing) at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v0.7/Random/src/Random.jl:386
  Stacktrace:
   [1] #solve#15(::Float64, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::NoiseProblem{NoiseProcess{Float64,1,Float64,Float64,Float64,Array{Float64,1},DiffEqNoiseProcess.GeometricBrownianMotion{Float64,Float64},getfield(DiffEqNoiseProcess, Symbol("##17#18")){DiffEqNoiseProcess.GeometricBrownianMotion{Float64,Float64}},false,DataStructures.Stack{Tuple{Float64,Float64,Float64}},ResettableStacks.ResettableStack{Tuple{Float64,Float64,Float64}},RSWM{:RSwM3,Float64},RandomNumbers.Xorshifts.Xoroshiro128Plus},Tuple{Float64,Float64}}) at /Users/jagot/.julia/dev/DiffEqNoiseProcess/src/solve.jl:12
   [2] (::getfield(DiffEqBase, Symbol("#kw##solve")))(::NamedTuple{(:dt,),Tuple{Float64}}, ::typeof(solve), ::NoiseProblem{NoiseProcess{Float64,1,Float64,Float64,Float64,Array{Float64,1},DiffEqNoiseProcess.GeometricBrownianMotion{Float64,Float64},getfield(DiffEqNoiseProcess, Symbol("##17#18")){DiffEqNoiseProcess.GeometricBrownianMotion{Float64,Float64}},false,DataStructures.Stack{Tuple{Float64,Float64,Float64}},ResettableStacks.ResettableStack{Tuple{Float64,Float64,Float64}},RSWM{:RSwM3,Float64},RandomNumbers.Xorshifts.Xoroshiro128Plus},Tuple{Float64,Float64}}) at ./none:0
```